### PR TITLE
Tick label delegate uses tickLabelFont instead of labelFont

### DIFF
--- a/QuickGraphLib/Axis.qml
+++ b/QuickGraphLib/Axis.qml
@@ -86,7 +86,7 @@ Item {
         color: root.labelColor
         decimalPoints: root.decimalPoints
         direction: root.direction
-        font: root.labelFont
+        font: root.tickLabelFont
     }
     /*!
         The color of the tick labels.


### PR DESCRIPTION
Currently the tick labels take on the same font as the axis labels even though they're meant to be independently configurable. 

Example:
```
QGLPreFabs.XYAxes {
    ...
    xAxis.labelFont.weight: Font.Bold
    xAxis.tickLabelFont.weight: Font.Normal
    ...
}
```
will result in bold axis title andtick labels, when it should have a bold axis label and normal weight tick labels.

Changing the font binding of the tick label delegate should hopefully fix this.