### PR TITLE
Fix raw data transform binding loop

### DIFF
--- a/QuickGraphLib/GraphArea.qml
+++ b/QuickGraphLib/GraphArea.qml
@@ -79,6 +79,7 @@ QQS.Shape {
     }
 
     clip: true
-    implicitHeight: 100
-    implicitWidth: 100
+    // Set initial size to prevent Shape's automatically calculated implicitWidth resulting in binding loops
+    height: 100
+    width: 100
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -164,7 +164,7 @@ h3#toc {
     margin-bottom: 0;
 }
 
-.qmlextra {
+.extra {
     float: right;
 }
 

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -116,12 +116,14 @@ Window {
         border.width: 0
 
         Loader {
+            id: loader
             source: exampleUrl
             anchors.fill: parent
+            asynchronous: true
         }
     }
     onFrameSwapped: {
-        if (root.hasExported) return;
+        if (root.hasExported || loader.status != Loader.Ready) return;
         content.ensurePolished();
         let res = content.grabToImage(result => {
             result.saveToFile(root.outputGrabUrl);


### PR DESCRIPTION
See https://bugreports.qt.io/browse/QTBUG-116482 for the Qt change. Overriding `implicitWidth/height` does not work, because Shape overwrites it unconditionally. Client code requiring fixed width/height can still override our choice, and Shapes should no longer require us to set implicit sizes to work in layouts.