### PR TITLE
Use renderer without real window; Add doc on single axis ZoomPanHandler

### DIFF
--- a/QuickGraphLib/ZoomPanHandler.qml
+++ b/QuickGraphLib/ZoomPanHandler.qml
@@ -27,6 +27,9 @@ PinchArea {
     property bool limitMovement: true
     /*!
         Maximum zoom (separate X/Y zoom limits can be set with the width/height of \l size).
+
+        Zooming on a particular axis can be disabled by setting the maximum scale for that axis to 1
+        (provided the minimum scale for that axis is left at it's default of 1).
     */
     property size maxScale: Qt.size(10, 10)
     /*!


### PR DESCRIPTION
Update test renderer to use the same API calls we use internally.

Add doc which was requested a while ago.